### PR TITLE
apply lexicographic ordering to releases

### DIFF
--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -5,6 +5,8 @@ import unittest
 
 import sphinx_multiversion
 
+from sphinx_multiversion.sphinx import normalize_version
+
 
 class VersionInfoTestCase(unittest.TestCase):
     def setUp(self):
@@ -26,6 +28,7 @@ class VersionInfoTestCase(unittest.TestCase):
                     "outputdir": os.path.join(root, "build", "html", "master"),
                     "confdir": os.path.join(root, "master", "docs"),
                     "docnames": ["testpage", "appendix/faq"],
+                    "commit": 0x1233456,
                 },
                 "v0.1.0": {
                     "name": "v0.1.0",
@@ -39,6 +42,7 @@ class VersionInfoTestCase(unittest.TestCase):
                     "outputdir": os.path.join(root, "build", "html", "v0.1.0"),
                     "confdir": os.path.join(root, "v0.1.0", "docs"),
                     "docnames": ["old_testpage", "appendix/faq"],
+                    "commit": 0xabcdef1234,
                 },
                 "branch-with/slash": {
                     "name": "branch-with/slash",
@@ -56,6 +60,7 @@ class VersionInfoTestCase(unittest.TestCase):
                     ),
                     "confdir": os.path.join(root, "branch-with/slash", "docs"),
                     "docnames": ["testpage"],
+                    "commit": 0x1234abcdef,
                 },
             },
             current_version_name="master",
@@ -69,7 +74,7 @@ class VersionInfoTestCase(unittest.TestCase):
         versions = self.versioninfo.branches
         self.assertEqual(
             [version.name for version in versions],
-            ["master", "branch-with/slash"],
+            ["branch-with/slash", "master"],
         )
 
     def test_releases_property(self):
@@ -80,7 +85,7 @@ class VersionInfoTestCase(unittest.TestCase):
         versions = self.versioninfo.in_development
         self.assertEqual(
             [version.name for version in versions],
-            ["master", "branch-with/slash"],
+            ["branch-with/slash", "master"],
         )
 
     def test_vhasdoc(self):
@@ -114,3 +119,69 @@ class VersionInfoTestCase(unittest.TestCase):
             self.versioninfo.vpathto("branch-with/slash"),
             posixpath.join("..", "..", "branch-with/slash", "index.html"),
         )
+
+
+def version_info_factory(name):
+
+    version_info = {
+        "name": name,
+        "version": "",
+        "release": "0.2",
+        "is_released": True,
+        "source": "heads",
+        "creatordate": "2020-08-07 07:45:20 -0700",
+        "basedir": "/dev/null",
+        "sourcedir": "/dev/null",
+        "outputdir": "/dev/null",
+        "confdir": "/dev/null",
+        "docnames": ["testpage", "appendix/faq"],
+        "commit": 0x1233456,
+    }
+
+    return version_info
+
+
+def test_sorting():
+
+    versions = [
+        "2.3.3",
+        "2.3.1",
+        "2.3.2",
+        "2.1.3",
+        "0",
+        "9",
+        "1.1",
+        "1.2",
+        "1.20",
+        "2.2",
+        "2.3",
+        "2.9.0",
+        "2.9.x",
+        "2.9.4",
+        "master",
+        "4",
+        "5.2",
+    ]
+
+    sorted_versions = sorted(versions, key=normalize_version)
+
+    metadata = {}
+    for version in versions:
+        metadata[version] = version_info_factory(version)
+        
+    version_info = sphinx_multiversion.sphinx.VersionInfo(
+        app=None,
+        context={"pagename": "testpage"},
+        metadata=metadata,
+        current_version_name="master",
+    )
+
+    releases = []
+    for vi in version_info.releases:
+        releases.append(vi.name)
+    assert releases == sorted_versions
+
+    branches = []
+    for vi in version_info.branches:
+        branches.append(vi.name)
+    assert branches == sorted_versions


### PR DESCRIPTION
Do so that a sort order could be applied to the Mitto releases in the TOC.
Seemed easier than some Jinja2 template magic.